### PR TITLE
Handled collation param for case insensitive indexes

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -236,7 +236,7 @@ class Service {
     const mapIds = page => page.data.map(current => current[this.id]);
 
     if (params.collation) {
-      query.collation = params.collation
+      query.collation = params.collation;
     }
 
     // By default we will just query for the one id. For multi patch
@@ -311,7 +311,7 @@ class Service {
     const query = Object.assign({}, filter(params.query || {}).query);
 
     if (params.collation) {
-      query.collation = params.collation
+      query.collation = params.collation;
     }
 
     if (id !== null) {

--- a/src/service.js
+++ b/src/service.js
@@ -59,6 +59,11 @@ class Service {
       q.sort(filters.$sort);
     }
 
+    // Handle collation
+    if (params.collation) {
+      q.collation(params.collation);
+    }
+
     // Handle $limit
     if (typeof filters.$limit !== 'undefined') {
       q.limit(filters.$limit);
@@ -230,6 +235,10 @@ class Service {
     const query = Object.assign({}, filter(params.query || {}).query);
     const mapIds = page => page.data.map(current => current[this.id]);
 
+    if (params.collation) {
+      query.collation = params.collation
+    }
+
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
@@ -300,6 +309,10 @@ class Service {
 
   remove (id, params) {
     const query = Object.assign({}, filter(params.query || {}).query);
+
+    if (params.collation) {
+      query.collation = params.collation
+    }
 
     if (id !== null) {
       query[this.id] = id;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,6 +107,98 @@ describe('Feathers Mongoose Service', () => {
     });
   });
 
+  describe('Special collation param', () => {
+    function indexOfName (results, name) {
+      let index;
+      results.every(function (person, i) {
+        if (person.name === name) {
+          index = i;
+          return false;
+        }
+        return true;
+      });
+      return index;
+    }
+
+    beforeEach(() => {
+      return people.remove(null, {}).then(() => {
+        return people.create([
+          { name: 'AAA' },
+          { name: 'aaa' },
+          { name: 'ccc' }
+        ]);
+      });
+    });
+
+    it('sorts with default behavior without collation param', () => {
+      return people.find({ query: { $sort: { name: -1 } } }).then(r => {
+        expect(indexOfName(r, 'aaa')).to.be.below(indexOfName(r, 'AAA'));
+      });
+    });
+
+    it('sorts using collation param if present', () => {
+      return people
+        .find({
+          query: { $sort: { name: -1 } },
+          collation: { locale: 'en', strength: 1 }
+        })
+        .then(r => {
+          expect(indexOfName(r, 'AAA')).to.be.below(indexOfName(r, 'aaa'));
+        });
+    });
+
+    it('removes with default behavior without collation param', () => {
+      return people
+        .remove(null, { query: { name: { $gt: 'AAA' } } })
+        .then(() => {
+          return people.find().then(r => {
+            expect(r).to.have.lengthOf(1);
+            expect(r[0].name).to.equal('AAA');
+          });
+        });
+    });
+
+    it('removes using collation param if present', () => {
+      return people
+        .remove(null, {
+          query: { name: { $gt: 'AAA' } },
+          collation: { locale: 'en', strength: 1 }
+        })
+        .then(() => {
+          return people.find().then(r => {
+            expect(r).to.have.lengthOf(3);
+          });
+        });
+    });
+
+    it('updates with default behavior without collation param', () => {
+      const query = { name: { $gt: 'AAA' } };
+
+      return people.patch(null, { age: 99 }, { query }).then(r => {
+        expect(r).to.have.lengthOf(2);
+        r.forEach(person => {
+          expect(person.age).to.equal(99);
+        });
+      });
+    });
+
+    it('updates using collation param if present', () => {
+      return people
+        .patch(
+          null,
+          { age: 110 },
+        {
+          query: { name: { $gt: 'AAA' } },
+          collation: { locale: 'en', strength: 1 }
+        }
+        )
+        .then(r => {
+          expect(r).to.have.lengthOf(1);
+          expect(r[0].name).to.equal('ccc');
+        });
+    });
+  });
+
   describe('Common functionality', () => {
     beforeEach(() => {
       // FIXME (EK): This is shit. We should be loading fixtures


### PR DESCRIPTION
### Summary
Handled collation parameter for supporting collation and case-insensitive indexes as introduced in MongoDB 3.4.

- [x] Tell us about the problem your pull request is solving.
Collation param is applied to allow for collation and case-insensitive indexing. 

- [x] Are there any open issues that are related to this?
Yes: [issue #211](https://github.com/feathersjs/feathers-mongoose/issues/211)

- [x] Is this PR dependent on PRs in other repos?
No
