### PR TITLE
Fix bug where regex fails in error-handler

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -5,7 +5,7 @@ module.exports = function errorHandler (error) {
     // NOTE (EK): Error parsing as discussed in this github thread
     // https://github.com/Automattic/mongoose/issues/2129
     const match1 = error.message.match(/_?([a-zA-Z]*)_?\d?\s*dup key/i);
-    const match2 = error.message.match(/\s*dup key:\s*\{\s*:\s*"?(\S+)"?\s*\}/i);
+    const match2 = error.message.match(/\s*dup key:\s*\{\s*:\s*"?(.*?)"?\s*\}/i);
 
     const key = match1 ? match1[1] : 'path';
     let value = match2 ? match2[1] : 'value';

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -125,7 +125,17 @@ describe('Feathers Mongoose Error Handler', () => {
       }).catch(done);
     });
 
-    it('has the correct error message', done => {
+    it('has the correct error message #1', done => {
+      let e = Error('E11000 duplicate key error collection: db.users index: name_1 dup key: { : "Kate" }');
+      e.name = 'MongoError';
+      e.code = 11000;
+      errorHandler(e).catch(error => {
+        expect(error.message).to.equal(`name: Kate already exists.`);
+        done();
+      }).catch(done);
+    });
+
+    it('has the correct error message #2', done => {
       let e = Error("E11000 duplicate key error index: myDb.myCollection.$id dup key: { : ObjectId('57226808ec55240c00000272') }");
       e.name = 'MongoError';
       e.code = 11000;
@@ -135,12 +145,22 @@ describe('Feathers Mongoose Error Handler', () => {
       }).catch(done);
     });
 
-    it('has the correct errors object', done => {
+    it('has the correct errors object #1', done => {
       let e = Error('E11000 duplicate key error index: test.collection.$a.b_1 dup key: { : null }');
       e.name = 'MongoError';
       e.code = 11000;
       errorHandler(e).catch(error => {
         expect(error.errors).to.deep.equal({ b: null });
+        done();
+      }).catch(done);
+    });
+
+    it('has the correct errors object #2', done => {
+      let e = Error('E11000 duplicate key error collection: db.users index: name_1 dup key: { : "Kate" }');
+      e.name = 'MongoError';
+      e.code = 11000;
+      errorHandler(e).catch(error => {
+        expect(error.errors).to.deep.equal({ name: 'Kate' });
         done();
       }).catch(done);
     });


### PR DESCRIPTION
### Summary

The regex inside the `errorHandler` does not work correctly for string values. If a `Conflict` occurs in the database where two string values clash (such as the name `"Kate"` in the tests) then the `value` variable was equal to `"Kate""` before this fix (please notice the extra double quote in the string).

This PR fixes that issue. The test cases added fail before the modification to the regex.