### PR TITLE
`estimatedDocumentCount` to `countDocuments`

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -99,7 +99,7 @@ class Service {
     }
 
     if (count) {
-      return model.where(query).[this.useEstimatedDocumentCount ? 'estimatedDocumentCount' : 'countDocuments']().exec().then(executeQuery);
+      return model.where(query)[this.useEstimatedDocumentCount ? 'estimatedDocumentCount' : 'countDocuments']().exec().then(executeQuery);
     }
 
     return executeQuery();

--- a/lib/service.js
+++ b/lib/service.js
@@ -30,6 +30,7 @@ class Service {
     this.lean = options.lean === undefined ? true : options.lean;
     this.overwrite = options.overwrite !== false;
     this.events = options.events || [];
+    this.useEstimatedDocumentCount = !!options.useEstimatedDocumentCount;
   }
 
   extend (obj) {
@@ -98,7 +99,7 @@ class Service {
     }
 
     if (count) {
-      return model.where(query).estimatedDocumentCount().exec().then(executeQuery);
+      return model.where(query).[this.useEstimatedDocumentCount ? 'estimatedDocumentCount' : 'countDocuments']().exec().then(executeQuery);
     }
 
     return executeQuery();


### PR DESCRIPTION
Set default for counting of total documents to `countDocuments`. Added option for using of `estimatedDocumentCount` instead.

Prior to this, we have found some inconsistencies with the total count that is returned from the find method.

![feathers-mongoose](https://user-images.githubusercontent.com/19768726/43765473-977d3f60-9a62-11e8-83d6-0c17abb0016d.png)
