### PR TITLE
Update default settings in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ app.service('messages').hooks({
   before: {
     patch(context) {
       // Set some additional Mongoose options
-      // The adapter tries to use sane defaults
+      // The adapter tries to use these settings by defaults
       // but they can always be changed here
       context.params.mongoose = {
         runValidators: true,


### PR DESCRIPTION
### Summary

The properties `runValidators` and `setDefaultsOnInsert` are set by defaults. I'd like to explain it more details (just for person with bad English skill like me) to understand correctly

### Other Information

Change documentation at [here](https://github.com/feathersjs-ecosystem/feathers-mongoose#paramsmongoose)