### PR TITLE
fix test because mongoose broke it

### DIFF
--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -82,7 +82,7 @@ describe('Feathers Mongoose Error Handler', () => {
   });
 
   it('wraps a VersionError as a BadRequest', done => {
-    let e = new mongoose.Error.VersionError({ _id: 'testing' });
+    let e = new mongoose.Error.VersionError({ _id: 'testing' }, null, []);
     errorHandler(e).catch(error => {
       expect(error).to.be.an.instanceof(errors.BadRequest);
       done();


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving.

The mongoose version npm installs broke the test for feathers-mongoose
https://travis-ci.org/superbarne/feathers-mongoose/builds/428944362
Because now we must pass an array to the VersionError function.
https://github.com/Automattic/mongoose/commit/a9962c7ffb66632987da299a90fd776ff3c8278a

- [x] Are there any open issues that are related to this?

no

- [x] Is this PR dependent on PRs in other repos?

no
