### PR TITLE
Feat: mongo opt to return writeResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ app.service('messages').hooks({
 
 The `mongoose` property is also useful for performing upserts on a `patch` request.  "Upserts" do an update if a matching record is found, or insert a record if there's no existing match.  The following example will create a document that matches the `data`, or if there's already a record that matches the `params.query`, that record will be updated.
 
-Using the `writeResult` mongoose option will append the mongo write result to returned documents, providing details of a `patch` operation. This can be helpful alongside the `upsert` flag, for detecting whether the outcome was a find or insert operation. If returning multiple documents, a `_writeResult` field will be added to the first document in the returned array. If returning a single document, the `_writeResult` field is added to that document. More on write results is available in the [Mongo documentation](https://docs.mongodb.com/manual/reference/method/db.collection.update/#writeresult)
+Using the `writeResult` mongoose option will return the write result of a `patch` operation, including the _ids of all upserted or modified documents. This can be helpful alongside the `upsert` flag, for detecting whether the outcome was a find or insert operation. More on write results is available in the [Mongo documentation](https://docs.mongodb.com/manual/reference/method/db.collection.update/#writeresult)
 
 ```js
 const data = { address: '123', identifier: 'my-identifier' }

--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ app.service('messages').hooks({
 
 The `mongoose` property is also useful for performing upserts on a `patch` request.  "Upserts" do an update if a matching record is found, or insert a record if there's no existing match.  The following example will create a document that matches the `data`, or if there's already a record that matches the `params.query`, that record will be updated.
 
+Using the `writeResult` mongoose option will append the mongo write result to returned documents, providing details of a `patch` operation. This can be helpful alongside the `upsert` flag, for detecting whether the outcome was a find or insert operation. If returning multiple documents, a `_writeResult` field will be added to the first document in the returned array. If returning a single document, the `_writeResult` field is added to that document. More on write results is available in the [Mongo documentation](https://docs.mongodb.com/manual/reference/method/db.collection.update/#writeresult)
+
 ```js
 const data = { address: '123', identifier: 'my-identifier' }
 const params = {
   query: { address: '123' },
-  mongoose: { upsert: true }
+  mongoose: { upsert: true, writeResult: true }
 }
 app.service('address-meta').patch(null, data, params)
 ```

--- a/lib/service.js
+++ b/lib/service.js
@@ -306,7 +306,7 @@ class Service {
                 }
               }
               return result;
-            })
+            });
         })
         .then(select(params, this.id))
         .catch(errorHandler);

--- a/lib/service.js
+++ b/lib/service.js
@@ -283,8 +283,6 @@ class Service {
             findParams.query.$populate = params.query.$populate;
           }
 
-          let patchWriteResult;
-
           // If params.query.$populate was provided, remove it
           // from the query sent to mongoose.
           const discriminator = (params.query || {})[this.discriminatorKey] || this.discriminatorKey;
@@ -294,18 +292,10 @@ class Service {
             .lean(this.lean)
             .exec()
             .then(writeResult => {
-              patchWriteResult = writeResult;
-              return this._getOrFind(id, findParams);
-            })
-            .then(result => {
               if (options.writeResult) {
-                if (Array.isArray(result)) {
-                  result[0]._writeResult = patchWriteResult;
-                } else {
-                  result._writeResult = patchWriteResult;
-                }
+                return writeResult;
               }
-              return result;
+              return this._getOrFind(id, findParams);
             });
         })
         .then(select(params, this.id))

--- a/lib/service.js
+++ b/lib/service.js
@@ -283,6 +283,8 @@ class Service {
             findParams.query.$populate = params.query.$populate;
           }
 
+          let patchWriteResult;
+
           // If params.query.$populate was provided, remove it
           // from the query sent to mongoose.
           const discriminator = (params.query || {})[this.discriminatorKey] || this.discriminatorKey;
@@ -291,7 +293,20 @@ class Service {
             .update(omit(query, '$populate'), data, options)
             .lean(this.lean)
             .exec()
-            .then(() => this._getOrFind(id, findParams));
+            .then(writeResult => {
+              patchWriteResult = writeResult;
+              return this._getOrFind(id, findParams);
+            })
+            .then(result => {
+              if (options.writeResult) {
+                if (Array.isArray(result)) {
+                  result[0]._writeResult = patchWriteResult;
+                } else {
+                  result._writeResult = patchWriteResult;
+                }
+              }
+              return result;
+            })
         })
         .then(select(params, this.id))
         .catch(errorHandler);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -226,20 +226,19 @@ describe('Feathers Mongoose Service', () => {
     });
 
     it('can upsert with patch & receive writeResult', function (done) {
-      var data = { name: 'Henry', age: 300 };
+      var data = { name: 'John', age: 200 };
       var params = {
         mongoose: { upsert: true, writeResult: true },
-        query: { name: 'Henry' }
+        query: { name: 'John' }
       };
 
       people.patch(null, data, params).then(data => {
-        expect(Array.isArray(data)).to.equal(true);
+        expect(data).to.be.instanceOf(Object);
+        expect(data).to.have.property('n', 1);
+        expect(data).to.have.property('ok', 1);
+        expect(data).to.have.property('nModified', 0);
+        expect(data).to.have.property('upserted').instanceOf(Array).with.length(1);
 
-        var henry = data[0];
-
-        expect(henry).property('_writeResult');
-        expect(henry._writeResult).instanceOf(Object);
-        expect(henry.name).to.equal('Henry');
         done();
       }).catch(done);
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -225,6 +225,25 @@ describe('Feathers Mongoose Service', () => {
       }).catch(done);
     });
 
+    it('can upsert with patch & receive writeResult', function (done) {
+      var data = { name: 'Henry', age: 300 };
+      var params = {
+        mongoose: { upsert: true, writeResult: true },
+        query: { name: 'Henry' }
+      };
+
+      people.patch(null, data, params).then(data => {
+        expect(Array.isArray(data)).to.equal(true);
+
+        var henry = data[0];
+
+        expect(henry).property('_writeResult');
+        expect(henry._writeResult).instanceOf(Object);
+        expect(henry.name).to.equal('Henry');
+        done();
+      }).catch(done);
+    });
+
     it('can $populate with update', function (done) {
       var params = {
         query: {


### PR DESCRIPTION
### Summary
#### Problem to solve
Currently no way of detecting what operation was carried out during a patch, with upsert set. It is often helpful to know whether the document(s) was (were) created or updated.

No dependent issues.

#### Proposed Solution
Using the writeResult option, users can opt to return the `writeResult` from patch.