### PR TITLE
Fix Mongoose update deprecation warning

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -297,7 +297,7 @@ class Service {
           const discriminator = (params.query || {})[this.discriminatorKey] || this.discriminatorKey;
           const model = this.discriminators[discriminator] || this.Model;
           return model
-            .updateOne(omit(query, '$populate'), data, options)
+            .updateMany(omit(query, '$populate'), data, options)
             .lean(this.lean)
             .exec()
             .then(() => this._getOrFind(id, findParams));

--- a/lib/service.js
+++ b/lib/service.js
@@ -297,7 +297,7 @@ class Service {
           const discriminator = (params.query || {})[this.discriminatorKey] || this.discriminatorKey;
           const model = this.discriminators[discriminator] || this.Model;
           return model
-            .update(omit(query, '$populate'), data, options)
+            .updateOne(omit(query, '$populate'), data, options)
             .lean(this.lean)
             .exec()
             .then(() => this._getOrFind(id, findParams));


### PR DESCRIPTION
Fixed DeprecationWarning for patch method.

(node:11888) DeprecationWarning: collection.update is deprecated. Use updateOne, updateMany, or bulkWrite instead.
https://mongoosejs.com/docs/deprecations.html

### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: