### PR TITLE
Pass through $select when PATCHing (for large documents)

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -290,16 +290,21 @@ class Service {
             }
           }) : params;
 
-          if (params.query && params.query.$populate) {
-            findParams.query.$populate = params.query.$populate;
+          if (params.query)
+            if (params.query.$populate) {
+              findParams.query.$populate = params.query.$populate;
+            }
+            if (params.query.$select) {
+              findParams.query.$select = params.query.$select;
+            }
           }
 
-          // If params.query.$populate was provided, remove it
+          // If params.query.$populate or $select was provided, remove it
           // from the query sent to mongoose.
           const discriminator = (params.query || {})[this.discriminatorKey] || this.discriminatorKey;
           const model = this.discriminators[discriminator] || this.Model;
           return model
-            .updateMany(omit(query, '$populate'), data, options)
+            .updateMany(omit(query, ['$populate', '$select']), data, options)
             .lean(this.lean)
             .exec()
             .then(writeResult => {

--- a/lib/service.js
+++ b/lib/service.js
@@ -290,7 +290,7 @@ class Service {
             }
           }) : params;
 
-          if (params.query)
+          if (params.query) {
             if (params.query.$populate) {
               findParams.query.$populate = params.query.$populate;
             }


### PR DESCRIPTION
Being able to use $select when patching would be very useful when dealing with larger documents. For instance, where a single field is being patched in a 1MB document, it would useful to be able to $select that single field to verify the change while also avoiding the overhead of reading and transferring the entire 1MB document. This proposed change passes $select through to the read after the patch.

I don't believe there are any open issues for this. Sorry if I should have opened one first to discuss whether you see this change as acceptable.