### PR TITLE
Fix $regex in params

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -12,11 +12,13 @@ class Service extends AdapterService {
     }
 
     super(Object.assign({
-      id: '_id'
+      id: '_id',
+      whitelist: ['$regex']
     }, options));
 
     this.discriminatorKey = this.Model.schema.options.discriminatorKey;
     this.discriminators = {};
+    
     (options.discriminators || []).forEach(element => {
       if (element.modelName) {
         this.discriminators[element.modelName] = element;


### PR DESCRIPTION
### Summary
whitelists $regex in default options so adapter-commons cleanQuery method no longer throws "Invalid query parameter $regex"