### PR TITLE
Expose original MongoDB error following feathers-sequelize methodology

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,6 +1,11 @@
 const errors = require('@feathersjs/errors');
+const ERROR = Symbol('feathers-mongoose/error');
 
-module.exports = function errorHandler (error) {
+const wrap = (error, original) => Object.assign(error);
+
+exports.ERROR = ERROR;
+
+exports.errorHandler = (error) => {
   if (error.code === 11000 || error.code === 11001) {
     // NOTE (EK): Error parsing as discussed in this github thread
     // https://github.com/Automattic/mongoose/issues/2129
@@ -21,7 +26,7 @@ module.exports = function errorHandler (error) {
       [key]: value
     };
 
-    return Promise.reject(new errors.Conflict(error));
+    return Promise.reject(wrap(new errors.Conflict(error), error));
   }
 
   if (error.name) {
@@ -30,14 +35,14 @@ module.exports = function errorHandler (error) {
       case 'ValidatorError':
       case 'CastError':
       case 'VersionError':
-        return Promise.reject(new errors.BadRequest(error));
+        return Promise.reject(wrap(new errors.BadRequest(error), error));
       case 'OverwriteModelError':
-        return Promise.reject(new errors.Conflict(error));
+        return Promise.reject(wrap(new errors.Conflict(error), error));
       case 'MissingSchemaError':
       case 'DivergentArrayError':
-        return Promise.reject(new errors.GeneralError(error));
+        return Promise.reject(wrap(new errors.GeneralError(error), error));
       case 'MongoError':
-        return Promise.reject(new errors.GeneralError(error));
+        return Promise.reject(wrap(new errors.GeneralError(error), error));
     }
   }
 

--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,7 +1,7 @@
 const errors = require('@feathersjs/errors');
 const ERROR = Symbol('feathers-mongoose/error');
 
-const wrap = (error, original) => Object.assign(error);
+const wrap = (error, original) => Object.assign(error, { [ERROR]: original });
 
 exports.ERROR = ERROR;
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -2,7 +2,7 @@ const { _ } = require('@feathersjs/commons');
 const { AdapterService, select } = require('@feathersjs/adapter-commons');
 const errors = require('@feathersjs/errors');
 
-const errorHandler = require('./error-handler');
+const { ERROR, errorHandler } = require('./error-handler');
 
 // Create the service.
 class Service extends AdapterService {
@@ -327,8 +327,12 @@ class Service extends AdapterService {
   }
 }
 
-module.exports = function init (options) {
+function init (options) {
   return new Service(options);
-};
+}
 
-module.exports.Service = Service;
+module.exports = Object.assign(init, {
+  default: init,
+  ERROR,
+  Service
+});

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const mongoose = require('mongoose');
 const errors = require('@feathersjs/errors');
 
-const errorHandler = require('../lib/error-handler');
+const { ERROR, errorHandler } = require('../lib/error-handler');
 
 describe('Feathers Mongoose Error Handler', () => {
   it('throws a feathers error', async () => {
@@ -202,6 +202,19 @@ describe('Feathers Mongoose Error Handler', () => {
         throw new Error('Should never get here');
       } catch (error) {
         expect(error.errors).to.deep.equal({ name: 'Kate' });
+      }
+    });
+
+    it('returns the original error', async () => {
+      let e = new Error('E11000 duplicate key error collection: db.users index: name_1 dup key: { : "Kate" }');
+      e.name = 'MongoError';
+      e.code = 11000;
+
+      try {
+        await errorHandler(e);
+        throw new Error('Should never get here');
+      } catch (error) {
+        expect(error[ERROR]).to.deep.equal(e);
       }
     });
   });


### PR DESCRIPTION
### Summary
This PR exposes the original MongoDB error along with the formatted one. This is done in the same way as the `feathers-sequelize` library ([see here](https://github.com/feathersjs-ecosystem/feathers-sequelize/blob/master/lib/utils.js)).
Due to limitations with parsing the original error message with regex to reformat it ([does not work for compound indexes](https://github.com/feathersjs-ecosystem/feathers-mongoose/issues/258)) it was decided that it would be best to also return the original error message to the user of the library so that they can understand the problem better in these scenarios.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this? [Yes](https://github.com/feathersjs-ecosystem/feathers-mongoose/issues/258), closes #258
- [x] Is this PR dependent on PRs in other repos? **No**