### PR TITLE
Fix: Transaction for find and get.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -84,7 +84,7 @@ class Service extends AdapterService {
       q.populate(filters.$populate);
     }
 
-    let executeQuery = total => q.exec().then(data => {
+    let executeQuery = total => q.session(params.mongoose && params.mongoose.session).exec().then(data => {
       return {
         total,
         limit: filters.$limit,
@@ -103,7 +103,8 @@ class Service extends AdapterService {
     }
 
     if (paginate && paginate.default) {
-      return model.where(query)[this.useEstimatedDocumentCount ? 'estimatedDocumentCount' : 'countDocuments']().exec().then(executeQuery);
+      return model.where(query)[this.useEstimatedDocumentCount ? 'estimatedDocumentCount' : 'countDocuments']()
+        .session(params.mongoose && params.mongoose.session).exec().then(executeQuery);
     }
 
     return executeQuery().then(page => page.data);
@@ -136,13 +137,14 @@ class Service extends AdapterService {
       modelQuery.select(filters.$select);
     }
 
-    return modelQuery.lean(this.lean).exec().then(data => {
-      if (!data) {
-        throw new errors.NotFound(`No record found for id '${id}'`);
-      }
+    return modelQuery.session(params.mongoose && params.mongoose.session)
+      .lean(this.lean).exec().then(data => {
+        if (!data) {
+          throw new errors.NotFound(`No record found for id '${id}'`);
+        }
 
-      return data;
-    }).catch(errorHandler);
+        return data;
+      }).catch(errorHandler);
   }
 
   _create (_data, params = {}) {


### PR DESCRIPTION
### Summary

Passed mongoose session for find and get method.

- [ ] Are there any open issues that are related to this? - No
- [ ] Is this PR dependent on PRs in other repos? - No

### Other Information

For any object creation or updation after beginning a new transaction, the subsequent find or get method will not return the saved data from a database before the transaction is committed, because the session-ID is not passed with the find-query. This pull request contains code changes that pass `params.mongoose.session` as options to the get and find methods to fetch data saved for the active session.