### PR TITLE
Incorrect results when multi-patchting properties included in data and query.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -261,6 +261,12 @@ class Service extends AdapterService {
     // NOTE (EK): We need this shitty hack because update doesn't
     // return a promise properly when runValidators is true. WTF!
     try {
+      const findQuery = !params.query ? null : Object.keys(params.query)
+        .reduce((query, key) => {
+          query[key] = data[key] === undefined ? params.query[key] : data[key];
+          return query;
+        }, {});
+
       return ids.then(idList => {
         // Create a new query that re-queries all ids that
         // were originally changed
@@ -268,9 +274,10 @@ class Service extends AdapterService {
           paginate: false,
           query: Object.assign({
             [this.id]: { $in: idList }
-          }, params.query)
+          }, findQuery)
         }) : Object.assign({}, params, {
-          paginate: false
+          paginate: false,
+          query: findQuery
         });
 
         // If params.query.$populate was provided, remove it

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -349,6 +349,13 @@ describe('Feathers Mongoose Service', () => {
       expect(data.name).to.equal('Doug');
     });
 
+    it('Returns correct result when queried properties ar patched', async () => {
+      const data = await pets.patch(null, { name: 'Spot' }, { query: { name: 'Rufus' } });
+      expect(data).to.be.an('array');
+      expect(data.length).to.equal(1);
+      expect(data[0].name).to.equal('Spot');
+    });
+
     it('can upsert with patch', async () => {
       const data = { name: 'Henry', age: 300 };
       const params = {


### PR DESCRIPTION
This PR is in relation to the issue originally reported [here]( https://github.com/feathersjs/feathers/issues/1221). 

## The problem
When performing a patch with a `null` id a property included in the query is being changed in the patch `data`, the patch happens successfully but an empty array is returned.

For example:
```JS
const data = await pets.patch(null, { name: 'Spot' }, { query: { name: 'Rufus' } });
```
changes Rufus to Spot in the database, but the return value is `[]`.

I found that, in the `_patch` function of `service.js`, there is a section labeled with
```JS
    // NOTE (EK): We need this shitty hack because update doesn't
    // return a promise properly when runValidators is true. WTF!
```
where the patch is performed, then a `_getOrFind` is run with the the original params to retrieve the updated afteward. 

Because the original query is re-used, but the data has been changed, the query doesn't find anything. 

## Proposed solution
I'm not sure if this is the best route to take because it is a hack on top of a hack, but the proposed change rebuilds the query, replacing anything that was both in the query and in data with the value from the data, using this "hybrid" query for the `_getOrFind` call after the patch. 

I've also added a test both to illustrate the problem and test the proposed solution. 



