### PR TITLE
Pass entity type to AdapterService<T>

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,7 +20,7 @@ export interface MongooseServiceOptions extends ServiceOptions {
   useEstimatedDocumentCount: boolean;
 }
 
-export class Service<T = any> extends AdapterService implements InternalServiceMethods<T> {
+export class Service<T = any> extends AdapterService<T> implements InternalServiceMethods<T> {
   Model: Model<any>;
   options: MongooseServiceOptions;
 


### PR DESCRIPTION
Version: `8.0.2` (latest at the time of writing)

Issue: SomeService.get and other service methods resolve to any, despite `<T>` being present (example below).

Solution: Fix declaration in d.ts by passing `<T>` to `AdapterService`

```ts
import { Service as MongooseService, MongooseServiceOptions } from 'feathers-mongoose';

export class SomeService extends MongooseService<User> {
  constructor(options: Partial<MongooseServiceOptions>, app: Application) {
    super(options);
  }
}
```