### PR TITLE
Merge whitelist to always include $and

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -11,15 +11,18 @@ class Service extends AdapterService {
       throw new Error('You must provide a Mongoose Model');
     }
 
+    const { whitelist = ['$regex'] } = options;
+
     super(Object.assign({
       id: '_id',
-      whitelist: ['$and', '$regex'],
       filters: Object.assign({
         $populate (value) {
           return value;
         }
       }, options.filters)
-    }, options));
+    }, options, {
+      whitelist: whitelist.concat('$and')
+    }));
 
     this.discriminatorKey = this.Model.schema.options.discriminatorKey;
     this.discriminators = {};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -162,6 +162,10 @@ describe('Feathers Mongoose Service', () => {
       expect(people.id).to.equal('_id');
     });
 
+    it('merges whitelist parameters (#347)', () => {
+      expect(people.options.whitelist).to.deep.equal(['$populate', '$and']);
+    });
+
     it('when missing the overwrite option sets the default to be true', () => {
       expect(people.overwrite).to.be.true;
     });


### PR DESCRIPTION
Makes sure that `$and` is always included since it is required by the adapter.

Closes #347