### PR TITLE
fix: handling of params.mongoose in transaction

### DIFF
--- a/lib/transaction-manager.js
+++ b/lib/transaction-manager.js
@@ -18,7 +18,7 @@ const beginTransaction = async (context, skipPath = []) => {
         const session = await client.startSession();
         await session.startTransaction();
         context.params.transactionOpen = true;
-        context.params.mongoose = { session };
+        context.params.mongoose = { ...context.params.mongoose, session };
       }
       context.enableTransaction = true; // true if transaction is enabled
     } else {


### PR DESCRIPTION
extend params.mongoose with session instead of replacing it

### Summary
Currently beginTransaction overrides the params.mongoose object:
`context.params.mongoose = { session };`

This causes issues if an operations depends on mongoose/mongodb params, for example when using arrayFilters or upsert (https://docs.mongodb.com/master/reference/method/db.collection.findAndModify/#findandmodify-arrayfilters)

Not sure if there was an intentional design decision behind overwriting it. If so, some sort of whitelisting for options should be included in my opinion.

- [x] Tell us about the problem your pull request is solving.
See desc
- [x] Are there any open issues that are related to this?
No, I just fixed it instead of opening one
- [x] Is this PR dependent on PRs in other repos?
No