### PR TITLE
update '_remove' method

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -304,14 +304,17 @@ class Service extends AdapterService {
     if (id !== null) {
       query.$and = (query.$and || []).concat({ [this.id]: id });
 
-      return this.Model.findOneAndDelete(query, params.mongoose).lean(this.lean)
-        .exec().then(result => {
+      return this.Model.findById(id)
+        .then((result) => {
           if (result === null) {
             throw new errors.NotFound(`No record found for id '${id}'`, query);
           }
-
-          return result;
-        }).then(select(params, this.id)).catch(errorHandler);
+          return this.Model.deleteOne(query, params.mongoose).lean(this.lean)
+            .exec()
+            .then(() => result)
+            .then(select(params, this.id));
+        })
+        .catch(errorHandler);
     }
 
     const findParams = Object.assign({}, params, {

--- a/lib/service.js
+++ b/lib/service.js
@@ -224,14 +224,14 @@ class Service extends AdapterService {
 
   _patch (id, data, params = {}) {
     const { query } = this.filterQuery(params);
-    const mapIds = data => data.map(current => current[this.id]);
+    const mapIds = data => Array.isArray(data) ? data.map(current => current[this.id]) : [data[this.id]];
 
     // By default we will just query for the one id. For multi patch
     // we create a list of the ids of all items that will be changed
     // to re-query them after the update
-    const ids = id === null ? this._find(Object.assign({}, params, {
+    const ids = this._getOrFind(id, Object.assign({}, params, {
       paginate: false
-    })).then(mapIds) : Promise.resolve([id]);
+    })).then(mapIds);
 
     // Handle case where data might be a mongoose model
     if (typeof data.toObject === 'function') {
@@ -268,7 +268,7 @@ class Service extends AdapterService {
         const { query: { $populate } = {} } = params;
         // Create a new query that re-queries all ids that
         // were originally changed
-        const updatedQuery = (idList.length && id === null) ? { [this.id]: { $in: idList } } : params.query;
+        const updatedQuery = { [this.id]: { $in: idList } };
         const findParams = Object.assign({}, params, {
           paginate: false,
           query: $populate ? Object.assign(updatedQuery, { $populate }) : updatedQuery
@@ -286,6 +286,9 @@ class Service extends AdapterService {
             if (options.writeResult) {
               return writeResult;
             }
+            if ('upserted' in writeResult) {
+              return this._getOrFind(id, Object.assign({}, params, { query: { [this.id]: { $in: writeResult.upserted.map(doc => doc._id) } } }, { paginate: false }));
+            }
             return this._getOrFind(id, findParams);
           });
       }).then(select(params, this.id)).catch(errorHandler);
@@ -301,36 +304,32 @@ class Service extends AdapterService {
       query.collation = params.collation;
     }
 
-    if (id !== null) {
-      query.$and = (query.$and || []).concat({ [this.id]: id });
-
-      return this.Model.findById(id)
-        .then((result) => {
-          if (result === null) {
-            throw new errors.NotFound(`No record found for id '${id}'`, query);
-          }
-          return this.Model.deleteOne(query, params.mongoose).lean(this.lean)
-            .exec()
-            .then(() => result)
-            .then(select(params, this.id));
-        })
-        .catch(errorHandler);
-    }
-
     const findParams = Object.assign({}, params, {
       paginate: false,
       query
     });
 
+    if (id !== null) {
+      query.$and = (query.$and || []).concat({ [this.id]: id });
+    }
+
     // NOTE (EK): First fetch the record(s) so that we can return
     // it/them when we delete it/them.
-    return this._getOrFind(id, findParams).then(data =>
-      this.Model.deleteMany(query, params.mongoose)
+    return this._getOrFind(id, findParams).then((data) => {
+      if (id !== null) {
+        return this.Model.deleteOne(query, params.mongoose)
+          .lean(this.lean)
+          .exec()
+          .then(() => data)
+          .then(select(params, this.id));
+      }
+
+      return this.Model.deleteMany(query, params.mongoose)
         .lean(this.lean)
         .exec()
         .then(() => data)
-        .then(select(params, this.id))
-    ).catch(errorHandler);
+        .then(select(params, this.id));
+    }).catch(errorHandler);
   }
 }
 


### PR DESCRIPTION
#361 

# Summary
Better support for shard cluster.

### Other Information
Replace `findOneAndDelete` with combination of `findById` and `deleteOne`, because in the shard cluster based on MongoDB specification if you are using `findOneAnd[*]` you have to pass entire shard key, which can be a combination of different fields.

This should not be required when you trying to remove document from the collection, just providing `_id` should be enough.