### PR TITLE
Add launch.json for mocha tests & fix typescript error.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Tests",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "-u",
+        "bdd",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,9 +1086,9 @@
       }
     },
     "definitelytyped-header-parser": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.8.1.tgz",
-      "integrity": "sha512-+uZhvbiVrNUHY1v3wlmnrWY3+jd4o8rLEho93CHrghbSzTixK5o7QdL66Rb2hmW/9nikGAarn1mBRhRyKKfyzQ==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-3.8.2.tgz",
+      "integrity": "sha512-kQePPP/cqQX3H6DrX5nCo2vMjJeboPsjEG8OOl43TZbTOr9zLlapWJ/oRCLnMCiyERsBRZXyLMtBXGM+1zmtgQ==",
       "dev": true,
       "requires": {
         "@types/parsimmon": "^1.3.0",
@@ -1172,30 +1172,30 @@
       }
     },
     "dts-critic": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-2.2.3.tgz",
-      "integrity": "sha512-65raFj90yesT1yl3zNVsx/ywGSs2ghytSGjZpaddnG8OLsezh/Cz3UaLHSEJFH5+K2vcuud4l0l5WeoXId0ptg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/dts-critic/-/dts-critic-2.2.4.tgz",
+      "integrity": "sha512-yGHhVKo66iyPBFUYRyXX1uW+XEG3/HDP1pHCR3VlPl9ho8zRHy6lzS5k+gCSuINqjNsV8UjZSUXUuTuw0wHp7g==",
       "dev": true,
       "requires": {
         "command-exists": "^1.2.8",
-        "definitelytyped-header-parser": "^3.8.1",
+        "definitelytyped-header-parser": "^3.8.2",
         "semver": "^6.2.0",
         "yargs": "^12.0.5"
       }
     },
     "dtslint": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-2.0.2.tgz",
-      "integrity": "sha512-ij6Y8uI/mYXrCk9mBcPDJeBQXI7jPMG7p08RFbnug63tesEdKzh+9PQhtCv27LMV+bw7vH5V2MPciSAr5tWtrA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-2.0.3.tgz",
+      "integrity": "sha512-6zTTsVPhomVfy+G+tGZfduzbLkGTKE/iid3IUy7fflaT4Atv0EqIcKKtkuUjrP45fWslI789E4u9e8ymn6Xyew==",
       "dev": true,
       "requires": {
-        "definitelytyped-header-parser": "3.8.1",
-        "dts-critic": "^2.2.3",
+        "definitelytyped-header-parser": "3.8.2",
+        "dts-critic": "^2.2.4",
         "fs-extra": "^6.0.1",
         "request": "^2.88.0",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^3.8.0-dev.20191206"
+        "typescript": "^3.8.0-dev.20200104"
       }
     },
     "ecc-jsbn": {
@@ -3933,9 +3933,9 @@
       }
     },
     "psl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
       "dev": true
     },
     "pump": {
@@ -5021,9 +5021,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.0-dev.20191206",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191206.tgz",
-      "integrity": "sha512-yeWDKxPNxAziB7VHOrkE48vqMga5vsB0qoy0N+um8JvK4aPeFMIRI3ke2ViwE8xibHLDo5ubfLqwVmqYnzVfMw==",
+      "version": "3.8.0-dev.20200104",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200104.tgz",
+      "integrity": "sha512-Zdb8X1uzvUPrRvRBqega83NxqCuN/kyxuXG1u8BV10mGOqfwQb0SreSDoDDM1zUgrqFZ93neVh3DVyWTvx6XlA==",
       "dev": true
     },
     "uberproto": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@feathersjs/socketio": "^4.4.1",
     "@types/mongoose": "^5.5.32",
     "chai": "^4.2.0",
-    "dtslint": "^2.0.2",
+    "dtslint": "^2.0.3",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^6.2.2",
     "mongoose": "^5.4.0",


### PR DESCRIPTION
- the typescript linter was breaking due to a change in Typescript 3.7.  I updated the dtslint package to fix the issue.
- I've also added a launch.json file to run and debug the Mocha tests inside vscode