### PR TITLE
Fix params.transactionOpen reset in rollback

### DIFF
--- a/lib/transaction-manager.js
+++ b/lib/transaction-manager.js
@@ -76,7 +76,7 @@ const rollbackTransaction = async context => {
       ) {
         await context.params.mongoose.session.abortTransaction();
         context.params.mongoose = null;
-        context.transactionOpen = false; // reset transaction-open
+        context.params.transactionOpen = false; // reset transaction-open
         context.enableTransaction = false;
       }
     }


### PR DESCRIPTION
### Summary

`rollbackTransaction` should reset `context.params.transactionOpen` instead of `context.transactionOpen`

- [x] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?
