### PR TITLE
Improved typing of Model property

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // TypeScript Version: 3.7
 import { Params, Paginated, Id, NullableId, Hook } from '@feathersjs/feathers';
 import { AdapterService, ServiceOptions, InternalServiceMethods } from '@feathersjs/adapter-commons';
-import { Model } from 'mongoose';
+import { Model, Document } from 'mongoose';
 
 export namespace hooks {
   function toObject(options?: any, dataField?: string): Hook;
@@ -13,16 +13,16 @@ export namespace transactionManager {
   const rollbackTransaction: Hook;
 }
 
-export interface MongooseServiceOptions extends ServiceOptions {
-  Model: Model<any>;
+export interface MongooseServiceOptions<T extends Document = any> extends ServiceOptions {
+  Model: Model<T>;
   lean: boolean;
   overwrite: boolean;
   useEstimatedDocumentCount: boolean;
 }
 
 export class Service<T = any> extends AdapterService<T> implements InternalServiceMethods<T> {
-  Model: Model<any>;
-  options: MongooseServiceOptions;
+  Model: Model<T & Document>;
+  options: MongooseServiceOptions<T & Document>;
 
   constructor(config?: Partial<MongooseServiceOptions>);
 


### PR DESCRIPTION
I have noticed that the `Model` property is not well typed on service classes backed by Mongoose (possibly others too but haven't investigated).

One way to fix this is in the `.class.ts` file, e.g. for `users.class.ts`:

```typescript
export interface User {
  username: string;
  password: string;
}

export class UserService extends Service<User> {
  Model!: Model<User & Document, {}>;
}
```

but it would be good to fix this in the underlying library so that the following works:

```typescript
export interface User {
  username: string;
  password: string;
}

export class UserService extends Service<User> {
}
```

I'm new to Typescript so not sure this is quite right but submitting this PR for your consideration or feedback.