### PR TITLE
fix: create returns undefined if data is empty array (for multi)

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -159,6 +159,7 @@ class Service extends AdapterService {
     const data = isMulti ? _data : [_data];
 
     return model.create(data, params.mongoose).then(results => {
+      if (results === undefined) return [];
       if ($populate) {
         return Promise.all(results.map(result => this.Model.populate(result, $populate)));
       }


### PR DESCRIPTION
Currently, if the service is defined as `multi = ['create']` and pass in empty array to `service.create`, it will throw `TypeError: Cannot read property 'map' of undefined`

Hence, this fix adds check to return empty array if the result is undefined so it exits early, and does not throw error

Also, because the test runs on `@feathersjs/adapter-tests`, I can add an updated test case to [.create multi](https://github.com/feathersjs/databases/blob/85e1e7a54bacfaabbf9478d0a71d40e710924746/packages/adapter-tests/src/methods.ts#L502) if required

```js
const emptyData = await service.create([]);

assert.ok(Array.isArray(emptyData));
assert.ok(emptyData.length === 0);
```

If this does gets accepted, do consider adding `topic` and `label` for [hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) so it counts towards the contribution