### PR TITLE
Add discriminators to MongooseServiceOptions type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,6 +20,7 @@ export interface MongooseServiceOptions<T extends Document = any> extends Servic
   useEstimatedDocumentCount: boolean;
   queryModifier?: (query: Query<any, any>, params: Params) => void;
   queryModifierKey?: string;
+  discriminators?: Model<T>[];
 }
 
 export class Service<T = any> extends AdapterService<T> implements InternalServiceMethods<T> {


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.

The code for using discriminators in services is there, but it's not in the type.

- [ ] Are there any open issues that are related to this?

I didn't see one!

- [ ] Is this PR dependent on PRs in other repos?

No.

If so, please mention them to keep the conversations linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Your PR will be reviewed by a core team member and they will work with you to get your changes merged in a timely manner. If merged your PR will automatically be added to the changelog in the next release.

If your changes involve documentation updates please mention that and link the appropriate PR in [feathers-docs](https://github.com/feathersjs/feathers-docs).

Thanks for contributing to Feathers! :heart: