### PR TITLE
Get $select should have the same signature as find

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -144,7 +144,7 @@ class Service extends AdapterService {
     }
 
     // Handle $select
-    if (filters.$select && filters.$select.length) {
+    if (Array.isArray(filters.$select)) {
       const fields = { [this.id]: 1 };
 
       for (const key of filters.$select) {
@@ -152,7 +152,7 @@ class Service extends AdapterService {
       }
 
       modelQuery.select(fields);
-    } else if (filters.$select && typeof filters.$select === 'object') {
+    } else if (typeof filters.$select === 'string' || typeof filters.$select === 'object') {
       modelQuery.select(filters.$select);
     }
 


### PR DESCRIPTION
Currently a string $select works for find, but it is ignored by get. This change makes both methods use $select consistently.